### PR TITLE
Implement the new move base flex interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(sbpl_lattice_planner)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS roscpp costmap_2d nav_core pluginlib 
-  geometry_msgs nav_msgs)
+  geometry_msgs nav_msgs mbf_costmap_core)
 find_package(catkin REQUIRED COMPONENTS
   ${THIS_PACKAGE_ROS_DEPS} message_generation)
 

--- a/bgp_mbf_plugin.xml
+++ b/bgp_mbf_plugin.xml
@@ -1,0 +1,8 @@
+<library path="lib/libsbpl_lattice_planner">
+  <class name="SBPLLatticePlanner" type="sbpl_lattice_planner::SBPLLatticePlanner" base_class_type="nav_core::BaseGlobalPlanner">
+    <description>
+      An implmentation of a search-based planning using anytime a* and a lattice graph
+    </description>
+  </class>
+</library>
+

--- a/include/sbpl_lattice_planner/sbpl_lattice_planner.h
+++ b/include/sbpl_lattice_planner/sbpl_lattice_planner.h
@@ -17,10 +17,11 @@ using namespace std;
 
 //global representation
 #include <nav_core/base_global_planner.h>
+#include <mbf_costmap_core/costmap_planner.h>
 
 namespace sbpl_lattice_planner{
 
-class SBPLLatticePlanner : public nav_core::BaseGlobalPlanner{
+class SBPLLatticePlanner : public nav_core::BaseGlobalPlanner, public mbf_costmap_core::CostmapPlanner{
 public:
   
   /**
@@ -56,6 +57,26 @@ public:
                         const geometry_msgs::PoseStamped& goal, 
                         std::vector<geometry_msgs::PoseStamped>& plan);
 
+  /**
+   * @brief Computes a plan.
+   * @param start  The start pose
+   * @param goal The goal pose
+   * @param tolerance The tolerance in x and y direction
+   * @param plan The computed plan
+   * @param cost The plan's cost
+   * @param message An message for Move Base Flex
+   * @return A status code. See Move Base Flex GetPath action for the codes.
+   */
+  virtual uint32_t makePlan(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
+                             double tolerance, std::vector<geometry_msgs::PoseStamped> &plan, double &cost,
+                             std::string &message);
+
+   /**
+   * @brief Requests the planner to cancel, e.g. if it takes too much time.
+   * @return True if a cancel has been successfully requested
+   */
+   virtual bool cancel();
+
   virtual ~SBPLLatticePlanner(){};
 
 private:
@@ -84,6 +105,8 @@ private:
   unsigned char lethal_obstacle_;
   unsigned char inscribed_inflated_obstacle_;
   unsigned char sbpl_cost_multiplier_;
+
+  bool canceled_;
 
 
   costmap_2d::Costmap2DROS* costmap_ros_; /**< manages the cost map for us */

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>sbpl</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>mbf_costmap_core</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>costmap_2d</run_depend>
@@ -29,10 +30,12 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>sbpl</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>mbf_costmap_core</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include" lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -lsbpl_lattice_planner"/>
     <nav_core plugin="${prefix}/bgp_plugin.xml" />
+    <mbf_costmap_core plugin="${prefix}/bgp_mbf_plugin.xml" />
   </export>
 
 </package>


### PR DESCRIPTION
The new move base flex API will be merged soon: https://github.com/magazino/move_base_flex/pull/78
With this PR, the planner will support the new `cancel()` method.
SBPL needs to be updated, too. See [this PR](https://github.com/sbpl/sbpl/pull/54) which adds a `cancel()` method to all planners.
Thanks!